### PR TITLE
fix errors on export where document body wasn't automatically created

### DIFF
--- a/scripts/dotgrid.js
+++ b/scripts/dotgrid.js
@@ -211,6 +211,7 @@ function Dotgrid(width,height,grid_x,grid_y,block_x,block_y,thickness = 3,lineca
   {
     var w = window.open('about:blank');
     w.document.write("<title>Export</title>");
+    w.document.write("<body></body>");
     w.document.body.innerText += vector_element.outerHTML;
   }
 


### PR DESCRIPTION
running both firefox and chromium on linux; i ran into errors when exporting since about:blank wasn't automatically creating a body for the new document. this one line fix took care of that for me.