### PR TITLE
refactor to be tiling window manager friendly

### DIFF
--- a/sources/index.html
+++ b/sources/index.html
@@ -17,19 +17,21 @@
     <title>Dotgrid(Icon)</title>
   </head>
   <body>
-    <script>
-      const {dialog,app} = require('electron').remote;
-      const fs = require('fs');
-      
-      dotgrid = new Dotgrid(300,300,20,20,4,4, 10,"square","#000000");
-      dotgrid.install();
+    <div id="app">
+      <script>
+        const {dialog,app} = require('electron').remote;
+        const fs = require('fs');
+        
+        dotgrid = new Dotgrid(300,300,20,20,4,4, 10,"square","#000000");
+        dotgrid.install();
 
-      var keyboard = new Keyboard();
+        var keyboard = new Keyboard();
 
-      document.onkeyup = function myFunction(event){ keyboard.listen(event); };
-      document.addEventListener('mousedown', function(e){ dotgrid.mouse_down(e); }, false);
-      document.addEventListener('mousemove', function(e){ dotgrid.mouse_move(e); }, false);
-      document.addEventListener('mouseup', function(e){ dotgrid.mouse_up(e);}, false);
-    </script>
+        document.onkeyup = function myFunction(event){ keyboard.listen(event); };
+        document.addEventListener('mousedown', function(e){ dotgrid.mouse_down(e); }, false);
+        document.addEventListener('mousemove', function(e){ dotgrid.mouse_move(e); }, false);
+        document.addEventListener('mouseup', function(e){ dotgrid.mouse_up(e);}, false);
+      </script>
+    </div>
   </body>
 </html>

--- a/sources/links/main.css
+++ b/sources/links/main.css
@@ -1,31 +1,37 @@
 body { background:#fff; padding: 5px; font-family: 'input_mono_regular'; -webkit-user-select: none; overflow: hidden;}
+#app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 
-#wrapper { width: calc(100% - 50px); height: calc(100% - 50px); padding: 25px; background: inherit;-webkit-app-region: drag;}
-#dotgrid { margin:0px auto; position:fixed; overflow: hidden; padding:10px;-webkit-app-region: no-drag; width:310px !important; height:310px !important; left:35px; top:35px;}
-#cursor { opacity: 1; transition: all 50ms; width:8px; height:8px; margin-top:-5px; margin-left:-5px; position:absolute; z-index:25; border-radius:5px; border:1px solid black;}
+#wrapper { padding: 25px; background: inherit;-webkit-app-region: drag;}
+#dotgrid { margin:0px auto; position:relative; overflow: hidden; padding:10px;-webkit-app-region: no-drag; width:310px !important; height:310px !important; }
+#cursor { opacity: 1; transition: all 50ms; width:8px; height:8px; position:absolute; z-index:25; border-radius:5px; border:1px solid black;}
 #cursor_coord { font-size:10px; z-index: 10000; margin-left:15px; margin-top:-2px;}
 #cursor_coord.left { margin-left:-110px; text-align: right; width:100px; }
-#cursor_from { width:4px; height:4px; background:white; margin-top:-3px; margin-left:-3px; position:absolute; z-index:2500; border-radius:10px; left:-100px;border:1px solid black;}
-#cursor_to { width:4px; height:4px; background:white; margin-top:-3px; margin-left:-3px; position:absolute; z-index:2500; border-radius:10px; left:-100px; border:1px solid black;}
-#cursor_end { width:4px; height:4px; background:white; margin-top:-3px; margin-left:-3px; position:absolute; z-index:2500; border-radius:10px; left:-100px; border:1px solid black;}
+#cursor_from { width:4px; height:4px; background:white; margin-top:2px; margin-left:2px; position:absolute; z-index:2500; border-radius:10px; left:-100px;border:1px solid black;}
+#cursor_to { width:4px; height:4px; background:white; margin-top:2px; margin-left:2px; position:absolute; z-index:2500; border-radius:10px; left:-100px; border:1px solid black;}
+#cursor_end { width:4px; height:4px; background:white; margin-top:2px; margin-left:2px; position:absolute; z-index:2500; border-radius:10px; left:-100px; border:1px solid black;}
 
-#guide,#widgets { position: absolute;top: 0px;left: 0px; width: 300px;height: 300px;}
-#widgets { z-index: 9000 }
+#guide,#widgets { position: absolute;width: 300px;height: 300px; margin-left: -5px; margin-top: -5px;}
+#widgets { z-index: 9000; margin-left: 0; margin-top: 0; }
 #render { display: none }
 
 .icon { width:25px; height:25px; margin-right:5px; opacity: 1}
 .icon:hover { cursor: pointer; opacity: 1 }
 
-svg.vector { z-index: 1000;position: relative; left:5px; top:5px; width:300px !important; height:300px !important; }
+svg.vector { z-index: 1000;position: relative; left:10px; top:10px; width:300px !important; height:300px !important; }
 
 #dotgrid #guide { opacity: 0; transition: all 500ms; }
-#dotgrid #widgets { opacity: 0; transition: all 150ms; left: 5px;top: 5px; }
+#dotgrid #widgets { opacity: 0; transition: all 150ms; }
 #dotgrid:hover #guide { opacity: 1 }
 #dotgrid:hover #widgets { opacity: 1 }
 
-#interface { max-width: 295px;margin: 0px auto;font-size: 11px;line-height: 30px;text-transform: uppercase;margin-top: 15px;-webkit-app-region: no-drag;position: fixed;bottom: 25px;left: 45px; transition: all 50ms;}
+#interface { font-size: 11px;line-height: 30px;text-transform: uppercase;-webkit-app-region: no-drag; transition: all 50ms;}
 #interface svg.inactive { opacity: 0.2 }
 #interface svg:hover { opacity: 0.5 }
+#interface svg.icon:last-child { margin-right: 0 }
 
 #interface.hidden { display: none;opacity: 0 }
 #interface.visible { display: block; opacity: 1 }

--- a/sources/scripts/dotgrid.js
+++ b/sources/scripts/dotgrid.js
@@ -51,7 +51,7 @@ function Dotgrid(width,height,grid_x,grid_y,block_x,block_y,thickness = 3,lineca
 
   this.install = function()
   {
-    document.body.appendChild(this.wrapper);
+    document.getElementById("app").appendChild(this.wrapper);
     this.wrapper.appendChild(this.element);
     this.element.appendChild(this.guide.el);
     this.element.appendChild(this.guide.widgets);

--- a/sources/scripts/interface.js
+++ b/sources/scripts/interface.js
@@ -6,7 +6,7 @@ function Interface()
 
   this.start = function()
   {
-    document.body.appendChild(this.el);
+    document.getElementById("app").appendChild(this.el);
 
     // Interface
     var html = ""


### PR DESCRIPTION
This messes with the styles so the setup runs in my tiling window manager i3. It adds an `div#app` which wraps all the things. I've used [flex](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) instead of some of the sizing things that were in there.


## Basic tiling 
![2_431](https://user-images.githubusercontent.com/2665886/32881920-9a1eb7a0-cb17-11e7-8116-71917bf8ff15.png)

## Tiling + zoom 
Dunno if it was my changes but means you can resize the tiled version and all the graphics scale NICE

![2_432](https://user-images.githubusercontent.com/2665886/32881917-99d5511e-cb17-11e7-9f0f-71bc9507f64a.png)

## Floating mode

![selection_434](https://user-images.githubusercontent.com/2665886/32882420-2cf559de-cb19-11e7-8908-393f80ddcd74.png)
