### PR TITLE
Implement serialization, clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 builds/
+package-lock.json

--- a/sources/index.html
+++ b/sources/index.html
@@ -9,6 +9,7 @@
     <script type="text/javascript" src="scripts/keyboard.js"></script>
     <script type="text/javascript" src="scripts/guide.js"></script>
     <script type="text/javascript" src="scripts/render.js"></script>
+    <script type="text/javascript" src="scripts/serializer.js"></script>
     <script type="text/javascript" src="scripts/theme.js"></script>
     <script type="text/javascript" src="scripts/interface.js"></script>
     <link rel="stylesheet" type="text/css" href="links/reset.css"/>
@@ -31,6 +32,8 @@
         document.addEventListener('mousedown', function(e){ dotgrid.mouse_down(e); }, false);
         document.addEventListener('mousemove', function(e){ dotgrid.mouse_move(e); }, false);
         document.addEventListener('mouseup', function(e){ dotgrid.mouse_up(e);}, false);
+        document.addEventListener('copy', function(e){ dotgrid.copy(e);}, false);
+        document.addEventListener('paste', function(e){ dotgrid.paste(e);}, false);
       </script>
     </div>
   </body>

--- a/sources/scripts/path_arc.js
+++ b/sources/scripts/path_arc.js
@@ -1,5 +1,6 @@
 function Path_Arc(from,to,orientation,end)
 {
+  this.__serialized_name__ = "Path_Arc";
   this.name = "arc";
 
   this.from = from;

--- a/sources/scripts/path_bezier.js
+++ b/sources/scripts/path_bezier.js
@@ -1,7 +1,8 @@
 function Path_Bezier(from,to,end)
 {
+  this.__serialized_name__ = "Path_Bezier";
   this.name = "bezier";
-
+  
   this.from = from;
   this.to = to;
   this.end = end;

--- a/sources/scripts/path_close.js
+++ b/sources/scripts/path_close.js
@@ -1,7 +1,8 @@
 function Path_Close()
 {
+  this.__type_ = "Path_Close";
   this.name = "close";
-
+  
   this.to_segment = function(prev)
   {
     return "Z ";

--- a/sources/scripts/path_line.js
+++ b/sources/scripts/path_line.js
@@ -1,7 +1,8 @@
 function Path_Line(from,to,end = null)
 {
+  this.__serialized_name__ = "Path_Line";
   this.name = "line";
-
+  
   this.from = from;
   this.to = to;
   this.end = end;

--- a/sources/scripts/pos.js
+++ b/sources/scripts/pos.js
@@ -1,5 +1,6 @@
 function Pos(x,y)
 {
+  this.__serialized_name__ = ".";  
   this.x = x;
   this.y = y;
 
@@ -40,3 +41,7 @@ function Pos(x,y)
 
   function clamp(v, min, max) { return v < min ? min : v > max ? max : v; }
 }
+
+// This is ugly, but Pos.__serialized_name__ == ".";
+// Let's keep the character count low.
+window["."] = Pos;

--- a/sources/scripts/serializer.js
+++ b/sources/scripts/serializer.js
@@ -1,0 +1,91 @@
+function Serializer()
+{
+  var __data_segments__ = 0;
+  var __data_thickness__ = 1;
+  var __data_linecap__ = 2;
+  var __data_color__ = 3;
+  var __data_mirror_index__ = 4;
+  var __data_fill__ = 5;
+
+  this.serialize = function()
+  {
+    // Store the data in an array.
+    // This keeps away the property names, which just clutter up everything.
+    var data = [
+      [],
+      dotgrid.thickness,
+      dotgrid.linecap,
+      dotgrid.color,
+      dotgrid.mirror_index,
+      dotgrid.fill
+    ];
+
+    for (var id in dotgrid.segments) {
+      data[__data_segments__][id] = this.serialize_segment(dotgrid.segments[id]);
+    }
+
+    return data;
+  }
+
+  this.deserialize = function(data)
+  {
+    if (data[__data_segments__]) {
+      for (var id in data[__data_segments__]) {
+        data[__data_segments__][id] = this.deserialize_segment(data[__data_segments__][id]);
+      }
+    }
+
+    var d = (index, fallback) => index < data.length ? data[index] : fallback;
+
+    dotgrid.segments = d(__data_segments__, []);
+    dotgrid.thickness = d(__data_thickness__, 10);
+    dotgrid.linecap = d(__data_linecap__, "square");
+    dotgrid.color = d(__data_color__, "#000000");
+    dotgrid.mirror_index = d(__data_mirror_index__, 0);
+    dotgrid.fill = d(__data_fill__, false);
+  }
+
+  this.serialize_segment = function(s) {
+    // Return falsy values (null, 0, false, "", ...) directly.
+    if (!s) return s;
+
+    var data = [";"];
+    // Get rid of non-serializable stuff (i.e. functions).
+    s = JSON.parse(JSON.stringify(s));
+    // Store everything in arrays instead of objects, saving characters.
+    for (var id in s) {
+      // Skip the non-serialzied path name.
+      if (s.__serialized_name__ && id === "name")
+        continue;
+      
+        var prop = s[id];
+
+      if (typeof(prop) === "object") {
+        prop = this.serialize_segment(prop);
+      }
+
+      data.push(prop);
+    }
+    return data;
+  }
+
+  this.deserialize_segment = function(data) {
+    var name = data.splice(0, 2)[1];
+
+    // Unserialize anything that's serialized.
+    for (var id in data) {
+      var prop = data[id];
+
+      if (prop && typeof(prop) === "object" && prop.length && prop[0] === ";") {
+        prop = this.deserialize_segment(prop);
+      }
+
+      data[id] = prop;
+    }
+
+    var s = {};
+    window[name].apply(s, data);
+    return s;
+  }
+
+}


### PR DESCRIPTION
This PR adds some basic serialization and copy - paste functionality.

Copying puts a serialized, plain-text representation of the image and a `text/svg+xml` representation in your system's clipboard. Unfortunately putting files into the system clipboard doesn't work at the moment (see https://bugs.chromium.org/p/chromium/issues/detail?id=504700), so I'm resorting to `text/svg+xml`. It's the same, except for storing the SVG as plain-text (similar to `text/html`), not as file.

This allows copying from Dotgrid and immediately pasting into rotonde:

![image](https://user-images.githubusercontent.com/1200380/33097683-3b339a74-cf0b-11e7-9544-6c857fe170c3.png)

The serialized result uses arrays instead of objects to keep clutter to a minimum:

```json
{"dotgrid":[[[";","Path_Line",[";",".",30,90],[";",".",60,60],[";",".",90,90]],[";","Path_Line",[";",".",60,180],[";",".",150,270],null]],10,"square","#000000",1,false]}
```

This could also be used to save Dotgrid "project" files.