### PR TITLE
Lowercased reference to dotgrid.js file.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script type="text/javascript" src="desktop/sources/scripts/lib/theme.js"></script>
     <script type="text/javascript" src="desktop/sources/scripts/lib/history.js"></script>
 
-    <script type="text/javascript" src="desktop/sources/scripts/DOTGRID.js"></script>
+    <script type="text/javascript" src="desktop/sources/scripts/dotgrid.js"></script>
     <script type="text/javascript" src="desktop/sources/scripts/cursor.js"></script>
     <script type="text/javascript" src="desktop/sources/scripts/guide.js"></script>
     <script type="text/javascript" src="desktop/sources/scripts/renderer.js"></script>


### PR DESCRIPTION
I lowercased the reference to dotgrid.js because the web version of Dotgrid wasn't loading correctly. (I was just seeing a blank page.) I didn't think that file names on the web were case sensitive like this, but changing the case seems to allow it to load correctly now.