### PR TITLE
Minimal viewBox for SVG exports

### DIFF
--- a/scripts/manager.js
+++ b/scripts/manager.js
@@ -24,7 +24,7 @@ function Manager (client) {
   this.update = function () {
     this.el.setAttribute('width', (client.tool.settings.size.width) + 'px')
     this.el.setAttribute('height', (client.tool.settings.size.height) + 'px')
-    this.el.style.width = (client.tool.settings.size.width)
+    this.el.style.width = client.tool.settings.size.width
     this.el.style.height = client.tool.settings.size.height
 
     const styles = client.tool.styles

--- a/scripts/manager.js
+++ b/scripts/manager.js
@@ -112,21 +112,6 @@ function Manager (client) {
     img.src = image64
   }
 
-  this.toSVG = function (callback) {
-    this.update()
-
-    const image64 = this.svg64()
-    callback(image64, 'export.svg')
-  }
-
-  this.toGRID = function (callback) {
-    this.update()
-
-    const text = client.tool.export()
-    const file = new Blob([text], { type: 'text/plain' })
-    callback(URL.createObjectURL(file), 'export.grid')
-  }
-
   this.toString = () => {
     const viewBox = this.minimalViewBox();
     if (viewBox !== '') {

--- a/scripts/manager.js
+++ b/scripts/manager.js
@@ -60,7 +60,6 @@ function Manager (client) {
 
       const path = paths[id]
       const matches = path.match(/\d+,\d+/g)
-      console.log(matches)
       if (matches === null) { continue }
 
       const coordinates = matches.map(p => p.split(/,/))
@@ -71,11 +70,6 @@ function Manager (client) {
       const xMaxOfLayer = Math.max(...xs) + offset
       const yMaxOfLayer = Math.max(...ys) + offset
 
-      console.log(xMinOfLayer)
-      console.log(yMinOfLayer)
-      console.log(xMaxOfLayer)
-      console.log(yMaxOfLayer)
-
       if (xMin === null || xMinOfLayer < xMin) { xMin = xMinOfLayer }
       if (yMin === null || yMinOfLayer < yMin) { yMin = yMinOfLayer }
       if (xMax === null || xMaxOfLayer > xMax) { xMax = xMaxOfLayer }
@@ -83,9 +77,7 @@ function Manager (client) {
     }
     if (xMin === null || yMin === null || xMax === null || yMax === null) { return '' }
 
-    const viewBox = xMin + ' ' + yMin + ' ' + (xMax - xMin) + ' ' + (yMax - yMin)
-    console.log(viewBox)
-    return viewBox
+    return xMin + ' ' + yMin + ' ' + (xMax - xMin) + ' ' + (yMax - yMin)
   }
 
   this.svg64 = function () {


### PR DESCRIPTION
When I export to svg, I usually want the file to have the same dimensions as the content, without any empty space around it. Right now this is only possible by manually editing the `.svg` output and adding a `viewBox` attribute, which requires calculating the minimal x and y values as well as the width and height of the content while taking into account the line thickness. The whole process can be quite time-consuming and error-prone for larger files.

The PR automatically calculates and saves the `viewBox` and tries to make sure that the resulting svg fits into these bounds. In the case of round or beveled line joins this is quite easy, but in the case of `miter` line joins (which could theoretically overshoot the angle point by quite a large amount in the case of sharp angles) an offset equivalent to the line thickness is used (which should give an acceptable result in most cases).