### PR TITLE
Fix history by tracking initial empty state and removal of segments

### DIFF
--- a/desktop/sources/scripts/lib/history.js
+++ b/desktop/sources/scripts/lib/history.js
@@ -2,10 +2,10 @@
 
 function History () {
   this.index = 0
-  this.a = []
+  this.a = [[[], [], []]]
 
   this.clear = function () {
-    this.a = []
+    this.a = [[[], [], []]]
     this.index = 0
   }
 

--- a/desktop/sources/scripts/tool.js
+++ b/desktop/sources/scripts/tool.js
@@ -96,6 +96,7 @@ function Tool (client) {
     if (this.vertices.length > 0) { this.clear(); return }
 
     this.layer().pop()
+    client.history.push(this.layers)
     this.clear()
     client.renderer.update()
     client.interface.update(true)
@@ -114,6 +115,7 @@ function Tool (client) {
         this.layers[this.index].splice(segmentId, 1)
       }
     }
+    client.history.push(this.layers)
     this.clear()
     client.renderer.update()
     client.interface.update(true)


### PR DESCRIPTION
Fixes 2 small issues:

  * I found it a bit unexpected that translating a segment is part of the undo/redo history, while removing a segment is not.
  * The first shape that is initially drawn cannot be undone since there is no 'empty state' to revert back to.